### PR TITLE
Configure nginx for subdomains

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ sudo ./install.sh
 
 O script instala Docker, Docker Compose, Node.js, PostgreSQL e configura um ambiente em `/opt/flow` com `docker-compose.yml` para iniciar os serviços.
 
+### Subdomínios padrão
+
+Durante a instalação é configurado o Nginx para expor cada aplicativo em um subdomínio do domínio `raelflow.com`:
+
+- `chat.raelflow.com` → Chatwoot
+- `n8n.raelflow.com` → n8n
+- `api.raelflow.com` → Evolution API
+- `crm.raelflow.com` → CRM de exemplo
+
+Certifique-se de criar os registros DNS correspondentes apontando para o servidor antes de executar o `install.sh`.
+
 ## Atualizações semanais
 
 Um cron job é criado automaticamente para rodar `update_services.sh` todo domingo às 3h da manhã. Este script atualiza os pacotes do sistema, baixa versões recentes dos containers e atualiza o n8n instalado via npm.

--- a/update_services.sh
+++ b/update_services.sh
@@ -5,3 +5,4 @@ cd /opt/flow
 /usr/bin/docker-compose pull
 /usr/bin/docker-compose up -d
 npm update -g n8n
+systemctl reload nginx


### PR DESCRIPTION
## Summary
- add nginx install and service setup
- expose each service via its own subdomain
- reload nginx during weekly updates
- document default subdomains in README

## Testing
- `bash -n install.sh`
- `bash -n update_services.sh`
- `npm install --prefix server`
- `npm start --prefix server` *(manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_688048bb575c8320ac00a73f52bb1106